### PR TITLE
Add options to speed up retry period.

### DIFF
--- a/dotlockfile.1
+++ b/dotlockfile.1
@@ -7,6 +7,8 @@ dotlockfile \- Utility to manage lockfiles
 .RB [ \-r
 .IR retries ]
 .RB [ \-p ]
+.RB [ \-s ]
+.RB [ \-B ]
 .RB < \-m \ |
 .IR lockfile >
 .br
@@ -15,6 +17,8 @@ dotlockfile \- Utility to manage lockfiles
 .RB [ \-r
 .IR retries ]
 .RB [ \-p ]
+.RB [ \-s ]
+.RB [ \-B ]
 .RB < \-m \ |
 .IR lockfile >
 .IR cmd "\ args \&...\&"
@@ -76,12 +80,17 @@ and has been touched less than 5\ minutes ago (timestamp is younger than
 The number of times
 .B dotlockfile
 retries to acquire the lock if it failed the first time before giving up.
-The initial sleep after failing to acquire the lock is 5\ seconds.
+By default, the initial sleep after failing to acquire the lock is 5\ seconds.
 After each retry the sleep interval is increased incrementally by 5\ seconds
 up to a maximum sleep of 60\ seconds between tries.
 The default number of retries is 5.
 To try only once, use "\fB\-r 0\fR".
 To try indefinitely, use "\fB\-r \-1\fR".
+.IP "\fB\-s\fR"
+Use a shorter sleep period of 1\ second, rather than the default 5\ seconds.
+.IP "\fB\-B\fR"
+Sleep for a constant period of time between each retry, rather than
+incrementally increasing the wait time.
 .IP "\fB\-u\fR"
 Remove a lockfile.
 .IP "\fB\-t\fR"

--- a/dotlockfile.c
+++ b/dotlockfile.c
@@ -94,7 +94,7 @@ int check_sleep(int sleeptime)
 	if (ppid == 0) ppid = getppid();
 
 	for (i = 0; i < sleeptime; i += 5) {
-		sleep(5);
+		sleep(1);
 		if (kill(ppid, 0) < 0 && errno == ESRCH)
 			return L_ERROR;
 	}

--- a/dotlockfile.c
+++ b/dotlockfile.c
@@ -166,8 +166,8 @@ void perror_exit(const char *why) {
  */
 void usage(void)
 {
-	fprintf(stderr, "Usage:  dotlockfile -l [-r retries] [-p] <-m|lockfile>\n");
-	fprintf(stderr, "        dotlockfile -l [-r retries] [-p] <-m|lockfile> command args...\n");
+	fprintf(stderr, "Usage:  dotlockfile -l [-r retries] [-s] [-B] [-p] <-m|lockfile>\n");
+	fprintf(stderr, "        dotlockfile -l [-r retries] [-s] [-B] [-p] <-m|lockfile> command args...\n");
 	fprintf(stderr, "        dotlockfile -u|-t\n");
 	exit(1);
 }
@@ -186,6 +186,8 @@ int main(int argc, char **argv)
 	int		check = 0;
 	int		touch = 0;
 	int		writepid = 0;
+	int		shortwait = 0;
+	int		nobackoff = 0;
 
 	/*
 	 *	Remember real and effective gid, and
@@ -209,7 +211,7 @@ int main(int argc, char **argv)
 	/*
 	 *	Process the options.
 	 */
-	while ((c = getopt(argc, argv, "+qpNr:mluct")) != EOF) switch(c) {
+	while ((c = getopt(argc, argv, "+qpNr:mluctsB")) != EOF) switch(c) {
 		case 'q':
 			quiet = 1;
 			break;
@@ -259,6 +261,12 @@ int main(int argc, char **argv)
 		case 't':
 			touch = 1;
 			break;
+		case 's':
+			shortwait = 1;
+			break;
+		case 'B':
+			nobackoff = 1;
+			break;
 		default:
 			usage();
 			break;
@@ -287,6 +295,12 @@ int main(int argc, char **argv)
 
 	if (writepid)
 		flags |= (cmd ? L_PID : L_PPID);
+
+	if (shortwait)
+		flags |= L_SHORTWAIT;
+
+	if (nobackoff)
+		flags |= L_NOBACKOFF;
 
 #ifdef MAXPATHLEN
 	if (strlen(lockfile) >= MAXPATHLEN) {

--- a/lockfile.h
+++ b/lockfile.h
@@ -40,8 +40,10 @@ int	lockfile_check(const char *lockfile, int flags);
 /*
  *	Flag values for lockfile_create()
  */
-#define L_PID		16	/* Put PID in lockfile			*/
-#define L_PPID		32	/* Put PPID in lockfile			*/
+#define L_PID		16	/* Put PID in lockfile						*/
+#define L_PPID		32	/* Put PPID in lockfile						*/
+#define L_SHORTWAIT	64	/* Only wait 1 second between retries		*/
+#define L_NOBACKOFF	128	/* Don't increase time between each retry	*/
 
 #ifdef  __cplusplus
 }


### PR DESCRIPTION
The purpose of this PR is to add two extra command-line options, and therefore two flags to `create_lockfile`. I have an application that needs to use lockfiles, but has a maximum of 15 seconds to operate. Waiting 5, then 10 seconds gives me 1 retry. The actual operations that will be performed take milliseconds, so this will hopefully improve the delay significantly.

The changes I have made are to add:

 - `-B` (with a flag named `L_NOBACKOFF`). This is an option that replaces the "Add 5 seconds wait after every failed retry" logic with the logic "retry every 5 seconds".
 - `s` (with a flag named `L_SHORTWAIT`).  This causes the 5 second wait period to become 1 second. 

The two options can work together; meaning there are actually four possible delay patterns now:
 - `wait 5, wait 10, wait 15, ... wait 60, wait 60` (by default)
 - `wait 5, wait 5, wait 5, ...` (with the `-B` option)
 - `wait 1, wait 2, wait 3, wait 4, ... wait 60, wait 60` (with the `-s` option)
 - `wait 1, wait 1, wait 1, ...` (with `-B -s`).