### PR TITLE
Add option '-i' for setting a consistent retry interval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
 .pc/
 .nfs*
+*.a
+*.o
+Makefile
+autoconf.h
+config.log
+config.status
+dotlockfile
+maillock.h

--- a/dotlockfile.1
+++ b/dotlockfile.1
@@ -6,6 +6,8 @@ dotlockfile \- Utility to manage lockfiles
 .B \-l
 .RB [ \-r
 .IR retries ]
+.RB [ \-i
+.IR interval ]
 .RB [ \-p ]
 .RB [ \-q ]
 .RB < \-m \ |
@@ -15,6 +17,8 @@ dotlockfile \- Utility to manage lockfiles
 .B \-l
 .RB [ \-r
 .IR retries ]
+.RB [ \-i
+.IR interval ]
 .RB [ \-p ]
 .RB [ \-q ]
 .RB < \-m \ |
@@ -61,8 +65,8 @@ were already taken \(en hence the name \fBdotlockfile\fR \fI:)\fR.
 .SH OPTIONS
 .IP "\fB\-l\fR"
 Create a lockfile if no preexisting valid lockfile is found, else wait and retry
-according to option \fB\-r\fR.
-This option is the default, so it can be left off.
+according to option \fB\-r\fR.  Retry interval can be explicitly set with option \fB\-i\fR.
+This option (\fB-l\fR) is the default, so it can be left off.
 
 A lockfile is treated as valid,
 .br
@@ -80,10 +84,12 @@ The number of times
 retries to acquire the lock if it failed the first time before giving up.
 The initial sleep after failing to acquire the lock is 5\ seconds.
 After each retry the sleep interval is increased incrementally by 5\ seconds
-up to a maximum sleep of 60\ seconds between tries.
+up to a maximum sleep of 60\ seconds between tries unless overridden by \fB\-i\fR.
 The default number of retries is 5.
 To try only once, use "\fB\-r 0\fR".
 To try indefinitely, use "\fB\-r \-1\fR".
+.IP "\fB\-i interval\fR"
+Sets a consistent retry interval.
 .IP "\fB\-u\fR"
 Remove a lockfile.
 .IP "\fB\-t\fR"

--- a/lockfile.c
+++ b/lockfile.c
@@ -19,6 +19,7 @@
 #endif
 #include <sys/stat.h>
 #include <sys/wait.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
 #include <signal.h>
@@ -40,7 +41,7 @@ static int  islocked = 0;
 #endif
 
 #ifndef LIB
-extern int check_sleep(int);
+extern int check_sleep(int, int);
 #endif
 
 #ifdef MAILGROUP
@@ -227,7 +228,7 @@ static int lockfilename(const char *lockfile, char *tmplock, int tmplocksz)
 static int lockfile_create_save_tmplock(const char *lockfile,
 		char *tmplock, int tmplocksz,
 		volatile char **xtmplock,
-		int retries, int flags)
+		int retries, int interval, int flags)
 {
 	struct stat	st, st1;
 	char		pidbuf[40];
@@ -287,14 +288,17 @@ static int lockfile_create_save_tmplock(const char *lockfile,
 	 *	Now try to link the temporary lock to the lock.
 	 */
 	for (i = 0; i < tries && tries > 0; i++) {
-
 		if (!dontsleep) {
-			sleeptime += 5;
+			if (flags & L_INTERVAL && interval > 0)
+				sleeptime = interval;
+			else
+				sleeptime += 5;
+
 			if (sleeptime > 60) sleeptime = 60;
 #ifdef LIB
 			sleep(sleeptime);
 #else
-			if ((e = check_sleep(sleeptime)) != 0) {
+			if ((e = check_sleep(sleeptime, flags)) != 0) {
 				unlink(tmplock);
 				tmplock[0] = 0;
 				return e;
@@ -378,7 +382,7 @@ static int lockfile_create_save_tmplock(const char *lockfile,
 #ifdef LIB
 static
 #endif
-int lockfile_create_set_tmplock(const char *lockfile, volatile char **xtmplock, int retries, int flags)
+int lockfile_create_set_tmplock(const char *lockfile, volatile char **xtmplock, int retries, int interval, int flags)
 {
 	char *tmplock;
 	int l, r, e;
@@ -388,7 +392,7 @@ int lockfile_create_set_tmplock(const char *lockfile, volatile char **xtmplock, 
 		return L_ERROR;
 	tmplock[0] = 0;
 	r = lockfile_create_save_tmplock(lockfile,
-						tmplock, l, xtmplock, retries, flags);
+						tmplock, l, xtmplock, retries, interval, flags);
 	if (xtmplock)
 		*xtmplock = NULL;
 	e = errno;
@@ -398,9 +402,18 @@ int lockfile_create_set_tmplock(const char *lockfile, volatile char **xtmplock, 
 }
 
 #ifdef LIB
-int lockfile_create(const char *lockfile, int retries, int flags)
+int lockfile_create(const char *lockfile, int retries, int flags, ...)
 {
-	return lockfile_create_set_tmplock(lockfile, NULL, retries, flags);
+	va_list args;
+	int interval = 0;
+
+	if (flags & L_INTERVAL) {
+		va_start(args, flags);
+		interval = va_arg(args, int);
+		va_end(args);
+	}
+
+	return lockfile_create_set_tmplock(lockfile, NULL, retries, interval, flags);
 }
 #endif
 

--- a/lockfile.c
+++ b/lockfile.c
@@ -312,7 +312,7 @@ static int lockfile_create_save_tmplock(const char *lockfile,
 		 *	EXTRA FIX: the value of the nlink field
 		 *	can't be trusted (may be cached).
 		 */
-		(void)link(tmplock, lockfile);
+		(void)!link(tmplock, lockfile);
 
 		if (lstat(tmplock, &st1) < 0) {
 			tmplock[0] = 0;

--- a/lockfile.h
+++ b/lockfile.h
@@ -20,7 +20,7 @@ extern "C" {
 /*
  *	Prototypes.
  */
-int	lockfile_create(const char *lockfile, int retries, int flags);
+int	lockfile_create(const char *lockfile, int retries, int flags, ...);
 int	lockfile_remove(const char *lockfile);
 int	lockfile_touch(const char *lockfile);
 int	lockfile_check(const char *lockfile, int flags);
@@ -43,6 +43,7 @@ int	lockfile_check(const char *lockfile, int flags);
  */
 #define L_PID		16	/* Put PID in lockfile			*/
 #define L_PPID		32	/* Put PPID in lockfile			*/
+#define L_INTERVAL	64	/* Specify consistent retry interval	*/
 
 #ifdef  __cplusplus
 }

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -38,5 +38,23 @@ fi
 wait
 [ ! -f testlock.lock ] || { echo "lockfile still exists after running cmd"; exit 1; }
 
+# test locking with given sleep interval
+dotlockfile -l -r 0 testlock.lock
+dotlockfile -l -i 4 testlock.lock /bin/true &
+
+time_start=$(date '+%s')
+
+sleep 4.5
+dotlockfile -u testlock.lock
+
+wait
+
+time_end=$(date '+%s')
+time_elapsed=`expr $time_end - $time_start`
+
+# Time should equal 8 seconds
+[ "$time_elapsed" = '8' ] || { echo "lockfile should take 8 seconds to be replaced. [$time_elapsed]"; exit 1; }
+[ ! -f testlock.lock ] || { echo "lockfile still exists after running cmd"; exit 1; }
+
 echo "tests OK"
 


### PR DESCRIPTION
This allows for some of our maintenance routines to have strictly bound wait times given a multiple of ```-r``` * ```-s```.