### PR TITLE
Makefile.in: fix install failure on host without ldconfig

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -9,6 +9,10 @@ NFSVER		= 0.1
 CFLAGS		= @CFLAGS@ -I.
 LDFLAGS		= @LDFLAGS@
 CC		= @CC@
+LDCONFIG        = @LDCONFIG@
+ifeq ($(LDCONFIG),)
+    LDCONFIG = ":"
+endif
 
 prefix		= $(DESTDIR)@prefix@
 exec_prefix	= @exec_prefix@
@@ -69,7 +73,7 @@ install_shared:	shared install_static install_common
 			$(libdir)/liblockfile.so.$(SOVER)
 		ln -s liblockfile.so.$(SOVER) $(libdir)/liblockfile.so.$(MAJOR)
 		ln -s liblockfile.so.$(SOVER) $(libdir)/liblockfile.so
-		if test "$(DESTDIR)" = ""; then @LDCONFIG@; fi
+		if test "$(DESTDIR)" = ""; then $(LDCONFIG); fi
 
 install_common:
 		install -d -m 755 -g root -p $(includedir)
@@ -88,7 +92,7 @@ install_common:
 install_nfslib:	nfslib
 		install -d -m 755 -g root -p $(nfslockdir)
 		install -m 755 nfslock.so.$(NFSVER) $(nfslockdir)
-		if test "$(DESTDIR)" = ""; then @LDCONFIG@; fi
+		if test "$(DESTDIR)" = ""; then $(LDCONFIG); fi
 
 test:		test-stamp
 		@:


### PR DESCRIPTION
* fix syntax error when ldconfig is not installed on host

when ldconfig is not installed on the build host, install will failed with error:
ln -sf nfslock.so.0.1 /mnt/tmp-glibc/work/core2-64-wrs-linux/liblockfile/1.14-r0/image/usr/lib64/nfslock.so.0 install -m 644 lockfile.h maillock.h /mnt/tmp-glibc/work/core2-64-wrs-linux/liblockfile/1.14-r0/image/usr/include if test "/mnt/tmp-glibc/work/core2-64-wrs-linux/liblockfile/1.14-r0/image" = ""; then ; fi if [ "mail" != "" ]; then\
          install -g mail -m 2755 dotlockfile /mnt/tmp-glibc/work/core2-64-wrs-linux/liblockfile/1.14-r0/image/usr/bin;\
        else \
          install -g root -m 755 dotlockfile /mnt/tmp-glibc/work/core2-64-wrs-linux/liblockfile/1.14-r0/image/usr/bin; \
        fi
/bin/sh: -c: line 1: syntax error near unexpected token `;' /bin/sh: -c: line 1: `if test "/mnt/tmp-glibc/work/core2-64-wrs-linux/liblockfile/1.14-r0/image" = ""; then ; fi'

* only run ldconfig when it exists